### PR TITLE
Feat: Retrieval Service 연동 클라이언트 및 로거 구현

### DIFF
--- a/backend/strategy_service/core/retrieval_client.py
+++ b/backend/strategy_service/core/retrieval_client.py
@@ -1,0 +1,34 @@
+
+import httpx
+import os
+from shared.models import RetrievalRequest
+
+# 환경변수에서 URL 가져오기 (없으면 로컬 기본값)
+RETRIEVAL_URL = os.getenv("RETRIEVAL_SERVICE_URL", "http://localhost:8003/api/v1/search")
+
+class RetrievalClient:
+    async def request_search(self, query: str, keywords: list):
+        payload = RetrievalRequest(
+            query=query,
+            keywords=keywords,
+            top_k=3
+        ).model_dump()
+        
+        print(f"📡 [Retrieval Client] 검색 요청 전송: {RETRIEVAL_URL}")
+        print(f"   ㄴ Payload: {payload}")
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(RETRIEVAL_URL, json=payload)
+                response.raise_for_status()
+                return response.json()
+        except Exception as e:
+            # [Mocking] 실제 서비스가 없어도 죽지 않게 가짜 데이터 반환
+            print(f"⚠️ [Mock] 검색 서비스 연결 실패 (테스트 환경): {e}")
+            return {
+                "status": "mock_success",
+                "documents": [
+                    {"title": "가짜 논문 1", "content": "검색 서비스가 아직 연결되지 않았습니다."},
+                    {"title": "가짜 논문 2", "content": "이것은 테스트용 더미 데이터입니다."}
+                ]
+            }

--- a/backend/strategy_service/requirements.txt
+++ b/backend/strategy_service/requirements.txt
@@ -11,3 +11,4 @@ peft
 torch
 accelerate
 python-dotenv
+httpx

--- a/backend/strategy_service/utils/logger.py
+++ b/backend/strategy_service/utils/logger.py
@@ -1,0 +1,27 @@
+
+import csv
+import os
+from datetime import datetime
+
+LOG_FILE = "ab_test_log.csv"
+
+def log_experiment(query, model_mode, keywords, latency):
+    file_exists = os.path.isfile(LOG_FILE)
+    
+    try:
+        with open(LOG_FILE, "a", newline="", encoding="utf-8-sig") as f:
+            writer = csv.writer(f)
+            # 파일이 없으면 헤더(제목) 작성
+            if not file_exists:
+                writer.writerow(["Timestamp", "Query", "Model", "Keywords", "Latency(ms)"])
+                
+            writer.writerow([
+                datetime.now().isoformat(),
+                query,
+                model_mode,
+                str(keywords),
+                latency
+            ])
+        print("📝 [Logger] 실험 결과 기록 완료")
+    except Exception as e:
+        print(f"❌ [Logger] 기록 실패: {e}")


### PR DESCRIPTION
## 🔍 개요
Strategy Service(키워드 생성)와 Retrieval Service(검색)를 **실제로 연결(Integration)**하고, A/B 테스트를 위한 **데이터 로깅 시스템**을 구축했습니다.

이제 `/api/v1/strategy/keywords` 엔드포인트를 호출하면 **[키워드 생성 → 로그 기록 → 검색 요청]**의 전체 파이프라인이 한 번에 실행됩니다.

## 🛠️ 작업 내용

### 1. 통신 규격 정의 (`backend/shared/models.py`)
* **`SimpleSearchRequest` 추가:**
    * 현재 복잡한 `SearchRequest` 대신, 초기 연동 테스트를 위해 **"키워드 리스트"만 담아 보낼 수 있는 경량화된 요청 모델**을 추가했습니다.
    * Retrieval Service 팀(@Nuri)은 이 모델을 참고하여 요청을 처리해주시면 됩니다.

### 2. Retrieval 연동 클라이언트 (`core/retrieval_client.py`)
* **`RetrievalClient` 구현:**
    * 생성된 키워드를 Retrieval Service API (`http://localhost:8003/...`)로 전송하는 비동기 HTTP 클라이언트입니다.
    * **Mocking 지원:** 현재 검색 서버가 닫혀있어도 Strategy Service가 중단되지 않도록, 실패 시 가짜 데이터(Mock Response)를 반환하는 안전장치를 포함했습니다.

### 3. A/B 테스트 로거 (`utils/logger.py`)
* **`log_experiment` 구현:**
    * 요청마다 `[시간, 질문, 사용모델(API/LoRA), 생성된키워드, 소요시간(Latency)]` 정보를 `ab_test_log.csv` 파일에 자동 기록합니다.
    * 추후 보고서 작성 시 정량적 지표(속도 비교 등)로 활용됩니다.

### 4. 통합 파이프라인 구성 (`main.py`)
* **엔드포인트 업데이트 (`/api/v1/strategy/keywords`):**
    * 기존: 키워드 생성만 수행.
    * **변경:** `Lifespan`으로 검색 클라이언트를 초기화하고, 생성된 키워드로 즉시 검색을 수행하여 최종 결과(논문 등)까지 반환하도록 확장했습니다.

## 🧪 테스트 방법
1.  서버 실행: `uvicorn backend.strategy_service.main:app --reload`
2.  POST 요청 예시:
    ```json
    {
      "query": "디지털 리터러시 논문 찾아줘",
      "mode": "lora"
    }
    ```
3.  확인 사항:
    * 응답 JSON에 `strategy_result`와 `retrieval_result`가 모두 포함되어 있는지 확인.
    * 프로젝트 루트에 `ab_test_log.csv` 파일이 생성되고 로그가 찍히는지 확인.

---

## 📢 To. Team
*  `shared/models.py` 맨 아래에 `SimpleSearchRequest`를 추가했으니 확인 부탁드립니다! 검색 API가 준비되면 연동 테스트 바로 가능합니다.
*  이 파이프라인은 모델 파일(`adapter`)이 없으면 Mock 모드로, 있으면 실제 모드로 자동 전환되니 안심하고 작업하세요.

## ✅ 체크리스트
- [x] Retrieval Service 연동 (Mocking 포함)
- [x] CSV 로그 기록 정상 작동 확인
- [x] `SimpleSearchRequest` 모델 정의